### PR TITLE
feat(11): Get geolocation data from proxy

### DIFF
--- a/netlify/edge-functions/geolocation.ts
+++ b/netlify/edge-functions/geolocation.ts
@@ -1,8 +1,30 @@
 import { GEO_HEADERS } from "./utils/constants.ts";
 import type { Config, Context } from "@netlify/edge-functions";
 
+type Geo = Context["geo"];
+type RequestHeaders = Pick<Request, "headers">;
+
+function getGeoHeaderValue({ headers }: RequestHeaders): Geo | null {
+  const geo = headers.get("x-geo-context");
+
+  if (geo === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(geo);
+  } catch (error) {
+    console.error("The header contained an invalid JSON.", error);
+    return null;
+  }
+}
+
 export default async function handler(request: Request, context: Context) {
-  const { country, city, latitude, longitude } = context.geo;
+  const geoContextHeader = getGeoHeaderValue(request);
+
+  const { country, city, latitude, longitude } =
+    geoContextHeader ?? context.geo;
+
   request.headers.set(GEO_HEADERS.country, country?.name ?? "");
   request.headers.set(GEO_HEADERS.city, city ?? "");
   request.headers.set(GEO_HEADERS.latitude, String(latitude ?? 0));
@@ -10,5 +32,5 @@ export default async function handler(request: Request, context: Context) {
 }
 
 export const config: Config = {
-  path: "/",
+  path: "/FEM_weather-app",
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  basePath: "",
-  assetPrefix: process.env.WEATHER_APP_PATH || "",
+  basePath: "/FEM_weather-app",
 };
 
 export default nextConfig;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const BASE_PATH = process.env.WEATHER_APP_PATH || "";
+export const BASE_PATH = "/FEM_weather-app";
 
 const HEADER_PREFIX = "geo";
 


### PR DESCRIPTION
# Description
This pull request extracts geo data from the custom header received from the reverse proxy. In case this is not present, it will fall back to the edge function context.geo value. 

# Changes
- Extract geo data from the custom header received from the reverse proxy.
- Add /FEM_weather-app as the basePath.

# Notes
- If the geo value falls back to this edge function context on the reverse proxy, the location values will display data related to the Netlify server and not the user. 
- Adding /FEM_weather-app as the basePath helps to keep paths consistent between the reverse proxy and the app